### PR TITLE
Fixes navigator defensive condition before changing page

### DIFF
--- a/src/js/core/navigator.js
+++ b/src/js/core/navigator.js
@@ -692,7 +692,8 @@
       if(currentPageObject.async) {
         callClose(currentPage, pageObject.name, hash);
       } else {
-        if(window.location.hash.indexOf(pageObject.name) === -1 && opts.useHash) {
+        var parsed = window.location.hash.split('/');
+        if(parsed[0].indexOf(pageObject.name) === -1 && opts.useHash) {
           window.location.hash = hash;
         }
       }


### PR DESCRIPTION
Before changing page, navigator checks if page is not already the one we want to go to. Which is ok.
Thing is if the name of this page is contained into params or action, page change will not occur.
This PR make it check only the current page name, not including params and action.