### PR TITLE
fix labels overlapping on top of input fields' value on fresh page load

### DIFF
--- a/dist/js/components/forms.js
+++ b/dist/js/components/forms.js
@@ -38,6 +38,12 @@
 		for (; i >= 0; i--) {
 			addListener(inputs[i]);
 		}
+
+		// Do this once at start also, otherwise pre-populated inputs will have labels directly overlapping on top of the input value on page load.
+		i = inputs.length - 1;
+		for (; i >= 0; i--) {
+			isInputFilled(inputs[i]);
+		}
 	});
 
 	/*


### PR DESCRIPTION
Issue:
- Prepopulate input-wrapper form fields with values let's say:
```
      <div class="input-wrapper">
          <input id="input-1" name="name" value={image.name} class="with-label" type="text">
          <label class="floating-label" for="input-1">Name</label>
      </div>
```

- Load the page.
- You will notice that the label is overlapping the text field value.

Solution:
Do the same check isInputFilled() also on pagecreated, not just on pageopened.
