### PR TITLE
Bugfix: TapElement start/move when clientX/clientY is 0 throws js error

### DIFF
--- a/src/js/core/events.js
+++ b/src/js/core/events.js
@@ -106,14 +106,14 @@ phonon.event = (function () {
 
             this.moved = false;
 
-            this.startX = e.clientX || e.touches[0].clientX;
-            this.startY = e.clientY || e.touches[0].clientY;
+            this.startX = (e.touches ? e.touches[0].clientX : e.clientX);
+            this.startY = (e.touches ? e.touches[0].clientY : e.clientY);
         };
 
         TapElement.prototype.move = function(e) {
 
-			var moveX = e.clientX || e.touches[0].clientX;
-            var moveY = e.clientY || e.touches[0].clientY;
+			var moveX = (e.touches ? e.touches[0].clientX : e.clientX);
+            var moveY = (e.touches ? e.touches[0].clientY : e.clientY);
 
             //if finger moves more than 10px flag to cancel
             if (Math.abs(moveX - this.startX) > 10 || Math.abs(moveY - this.startY) > 10) {


### PR DESCRIPTION
Code in TapElement tests for mouse vs touch events using
e.clientX || e.touches[0].clientX logic
which breaks when clientX is 0, attempting to dereference non-existing e.touches.

I noticed this on the desktop with the console open - seems like it should be desktop only.

Propsed fix follows the way tabs.js does it.