### PR TITLE
Allowing programmatically changing to $previous-page

### DIFF
--- a/src/js/core/navigator.js
+++ b/src/js/core/navigator.js
@@ -1096,6 +1096,13 @@
         var wait = (isComponentVisible() ? 400 : 1);
 
         window.setTimeout(function() {
+          if (pageName == '$previous-page') {
+            var last = getLastPage();
+            if (last) {
+              pageName = last.page;
+              pageParams = last.params;
+            }    
+          }    
           changePage(pageName, pageParams);
         }, wait);
       },


### PR DESCRIPTION
This allows going programmatically to `$previous-page` like:

    phonon.navigator().changePage('$previous-page');

I agree that this could also be a separate method, but this is consistent with the `data-navigation` trick