### PR TITLE
Dialogs: siring confirm event on [enter] (13) key pressed

### DIFF
--- a/src/js/ui/dialogs.js
+++ b/src/js/ui/dialogs.js
@@ -178,7 +178,11 @@
 
 			if(evt.which == 13 || evt.keyCode == 13) {
 				var previous = dialogs[dialogs.length - 1];
-				close(previous.dialog);
+                                var btnConfirm = previous.dialog.querySelector('.btn-confirm');
+                                if (btnConfirm && typeof btnConfirm.fireConfirm != 'undefined') {
+                                    btnConfirm.fireConfirm();
+                                }
+                                close(previous.dialog);
 
 				return false;
 			}
@@ -281,6 +285,7 @@
 		if(eventName === 'confirm') {
 			var btnConfirm = dialog.querySelector('.btn-confirm');
 			if(btnConfirm) {
+                                btnConfirm.fireConfirm = fireEvent;
 				btnConfirm.on('tap', fireEvent);
 			}
 		} else {


### PR DESCRIPTION
With this change, pressing "enter" key triggers the confirm event before closing dialogs

Thus, you can validate a prompt with virtual keyboard enter key