### PR TITLE
Avoiding backbutton when a dialog is visible

### DIFF
--- a/src/js/core/navigator.js
+++ b/src/js/core/navigator.js
@@ -1070,6 +1070,7 @@
   if(opts.useHash) window.addEventListener('hashchange', onRoute);
 
   document.on('backbutton', function() {
+    if(isComponentVisible()) return;
     var last = getLastPage();
     callClose(currentPage, last.page, opts.hashPrefix + last.page + '/' + last.params);
   });


### PR DESCRIPTION
This fixes the sequence of pages when using the physical back button when dialogs are shown

Note that with this fix, the back button still closes the dialog for me (not sure but I guess it also triggers the tap event?)