### PR TITLE
Fix for ios problem. Requires the user to create a language.s file wi…

### DIFF
--- a/kitchen-sink/app.js
+++ b/kitchen-sink/app.js
@@ -1,3 +1,11 @@
+function getLang()
+{
+ if (navigator.languages != undefined) 
+ 	return navigator.languages[0]; 
+ else 
+ 	return navigator.language;
+}
+
 phonon.options({
 
 	navigator: {
@@ -10,7 +18,7 @@ phonon.options({
 	i18n: {
 		directory: 'lang/',
 		localeFallback: 'en',
-		localePreferred: 'en-US'
+		localePreferred: getLang()
 	}
 });
 

--- a/kitchen-sink/index.html
+++ b/kitchen-sink/index.html
@@ -122,8 +122,10 @@
 
         <pagetabs data-page="true"></pagetabs>
         <pagetable data-page="true"></pagetable>
-
-
+<!-- Uncomment this if you are using cordova/phonegan and iOS platform.
+     remember to populate the file
+        <script src="language.js"></script>
+-->
         <script src="../dist/js/phonon.js"></script>
         <script src="app.js"></script>
     </body>

--- a/kitchen-sink/language.js
+++ b/kitchen-sink/language.js
@@ -1,0 +1,37 @@
+/*
+ * language.js
+ * 
+ */
+
+var langCache = [];
+langCache['es-ES'] = {
+	"welcome":"Bienvenido",
+	"desc":"Esto es un ejemplo",
+	"french":"Frances",
+	"global_english":"Inglés estandard",
+	"us_english":"Inglés americano"
+};
+
+langCache['en'] = {
+	"welcome":"Welcome (Global English)",
+	"desc":"This is a sample",
+	"french":"French",
+	"global_english":"Global English",
+	"us_english":"US English"
+};
+
+langCache['en-US'] = {
+	"welcome":"Welcome (US English)",
+	"desc":"This is a sample",
+	"french":"French",
+	"global_english":"Global English",
+	"us_english":"US English"
+};
+
+langCache['fr'] = {
+	"welcome":"Bienvenue",
+	"desc":"Ceci est un exemple",
+	"french":"Français",
+	"global_english":"Anglais",
+	"us_english":"Anglais USA"
+}

--- a/src/js/core/i18n.js
+++ b/src/js/core/i18n.js
@@ -147,14 +147,23 @@
             throw new Error('callback must be a function');
         }
 
+        var locale = opts.localePreferred ? opts.localePreferred : opts.localeFallback;
+
+        if (typeof langCache != 'undefined') {
+          // FIX iOS. User provides a langCache Array
+          if (!(locale in langCache)) {
+              console.log('The language [' + locale + '] is not available, loading ' + opts.localeFallback);
+              locale = opts.localeFallback;
+          }
+          jsonCache = langCache[locale];
+        }
+
         if(jsonCache !== null) {
             callback(jsonCache);
             return;
         }
 
         var xhr = new XMLHttpRequest();
-
-        var locale = opts.localePreferred ? opts.localePreferred : opts.localeFallback;
 
         xhr.open('GET', opts.directory + locale + '.json', true);
         if(xhr.overrideMimeType) xhr.overrideMimeType('application/json; charset=utf-8');


### PR DESCRIPTION
The only solution for COR file:/// problem is to avoid the json loading. So I created a .js containing all the json contents (in this case by hand, but it can be done using a script in a hook on cordova). The system remains the same if you are not in a os with problems, but load the translations correctly on iOs