### PR TITLE
phonon.notif([...]) now returns the created/selected element

### DIFF
--- a/src/js/ui/notifications.js
+++ b/src/js/ui/notifications.js
@@ -260,6 +260,7 @@
 			var generatedNotif = buildNotif(el, timeout, showButton);
 			show(generatedNotif);
 			return {
+				element: generatedNotif,
 				setColor: function (color) {
 					setColor(generatedNotif, color);
 				}
@@ -272,6 +273,7 @@
 		}
 
 		return {
+			element: notif,
 			show: function () {
 				show(notif)
 				return this


### PR DESCRIPTION
This makes it easier to further manipulate the element via code, which is especially helpful upon generating a new "predefined notification".

For example, I want my app to display all the received push notifications with this method when in foreground, but in a few cases I need to add an event listener on the generated element to make it interactable.