### PR TITLE
improved "native feeling" for tabs

### DIFF
--- a/src/js/ui/tabs.js
+++ b/src/js/ui/tabs.js
@@ -453,6 +453,11 @@
         var parsedEvent = this._parseEvent(event),
             coordinates = this._checkOverscroll( parsedEvent.direction , - parsedEvent.distanceX, - parsedEvent.distanceY );
 
+        // @phonon => prevent animation if it is a vertical swipe
+        if (Math.abs(xDiff) < Math.abs(yDiff)){
+            return;
+        }
+
         // @phonon => disable extensible tab content
         if(this.page === 0 && parsedEvent.direction === 'right') {
           return;
@@ -1045,6 +1050,7 @@
 
 	    var options = {
 	        direction: 'horizontal',
+            minDragDistance: "100",
 	        preventDrag: preventDrag,
 	        duration: 200,
 	        pageClass: 'tab-content',


### PR DESCRIPTION
I think the tabs have a more "native feeling" if they don't follow the finger when the direction of the swipe is mainly vertical.

To prevent triggering a tab change accidentally while trying to scroll the page down I've also increased minDragDistance to 100px.